### PR TITLE
updated Linter version to 0.1.12 (to fix build)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,9 +79,7 @@ libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
 /// Compiler plugins
 
 // linter: static analysis for scala
-resolvers += "Linter Repository" at "https://hairyfotr.github.io/linteRepo/releases"
-
-addCompilerPlugin("com.foursquare.lint" %% "linter" % "0.1.8")
+addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.12")
 
 
 /// console


### PR DESCRIPTION
I updated the Linter dependency to 0.1.12 according to https://github.com/HairyFotr/linter, previously the build was failing due to a failure in finding the dependency that was specified in build.sbt

Great work on this template, it is very helpful, thank you!
